### PR TITLE
Add skeleton Go port

### DIFF
--- a/gosqlparse/engine/filterstack/stack.go
+++ b/gosqlparse/engine/filterstack/stack.go
@@ -1,0 +1,30 @@
+package filterstack
+
+import (
+	"gosqlparse/engine/grouping"
+	"gosqlparse/engine/statementsplitter"
+	"gosqlparse/lexer"
+	"gosqlparse/sql"
+)
+
+// FilterStack coordinates tokenization and grouping.
+type FilterStack struct {
+	doGrouping bool
+}
+
+func New() *FilterStack { return &FilterStack{} }
+
+func (fs *FilterStack) EnableGrouping() { fs.doGrouping = true }
+
+// Run parses SQL text and returns statements.
+func (fs *FilterStack) Run(sqlText string) []*sql.Statement {
+	lex := lexer.New()
+	tokens := lex.Tokenize(sqlText)
+	stmts := statementsplitter.Split(tokens)
+	if fs.doGrouping {
+		for _, s := range stmts {
+			grouping.Group(s)
+		}
+	}
+	return stmts
+}

--- a/gosqlparse/engine/grouping/grouping.go
+++ b/gosqlparse/engine/grouping/grouping.go
@@ -1,0 +1,10 @@
+package grouping
+
+import "gosqlparse/sql"
+
+// Group is a placeholder grouping step.
+func Group(stmt *sql.Statement) {
+	// In a full implementation, this would collapse tokens into
+	// structures like Identifier, Parenthesis, etc.
+	// For now we do nothing.
+}

--- a/gosqlparse/engine/statementsplitter/splitter.go
+++ b/gosqlparse/engine/statementsplitter/splitter.go
@@ -1,0 +1,27 @@
+package statementsplitter
+
+import (
+	"gosqlparse/sql"
+	"gosqlparse/tokens"
+)
+
+// Split splits tokens into statements based on semicolons.
+func Split(toks []*sql.Token) []*sql.Statement {
+	var stmts [][]*sql.Token
+	current := []*sql.Token{}
+	for _, t := range toks {
+		current = append(current, t)
+		if t.Type == tokens.Punctuation && t.Value == ";" {
+			stmts = append(stmts, current)
+			current = []*sql.Token{}
+		}
+	}
+	if len(current) > 0 {
+		stmts = append(stmts, current)
+	}
+	out := make([]*sql.Statement, 0, len(stmts))
+	for _, s := range stmts {
+		out = append(out, sql.NewStatement(s))
+	}
+	return out
+}

--- a/gosqlparse/go.mod
+++ b/gosqlparse/go.mod
@@ -1,0 +1,3 @@
+module gosqlparse
+
+go 1.20

--- a/gosqlparse/lexer/lexer.go
+++ b/gosqlparse/lexer/lexer.go
@@ -1,0 +1,60 @@
+package lexer
+
+import (
+	"regexp"
+
+	"gosqlparse/sql"
+	"gosqlparse/tokens"
+)
+
+// Lexer implements a simple regex-based scanner.
+type Lexer struct {
+	patterns []lexEntry
+}
+
+type lexEntry struct {
+	regex *regexp.Regexp
+	ttype tokens.TokenType
+}
+
+func New() *Lexer {
+	l := &Lexer{}
+	l.patterns = []lexEntry{
+		{regexp.MustCompile(`^\s+`), tokens.Whitespace},
+		{regexp.MustCompile(`^[(),;]`), tokens.Punctuation},
+		{regexp.MustCompile(`^'(?:''|[^'])*'`), tokens.String},
+		{regexp.MustCompile(`^\d+`), tokens.Number},
+		{regexp.MustCompile(`^[a-zA-Z_][\w]*`), tokens.Identifier},
+	}
+	return l
+}
+
+// Tokenize converts SQL text into token objects.
+func (l *Lexer) Tokenize(sqlText string) []*sql.Token {
+	var tokensOut []*sql.Token
+	for len(sqlText) > 0 {
+		matched := false
+		for _, p := range l.patterns {
+			if loc := p.regex.FindStringIndex(sqlText); loc != nil && loc[0] == 0 {
+				val := sqlText[:loc[1]]
+				tok := &sql.Token{
+					Type:         p.ttype,
+					Value:        val,
+					IsWhitespace: p.ttype == tokens.Whitespace,
+					IsKeyword:    false,
+				}
+				tokensOut = append(tokensOut, tok)
+				sqlText = sqlText[loc[1]:]
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			// consume one rune as illegal token
+			tok := &sql.Token{Type: tokens.Illegal, Value: string(sqlText[0])}
+			tokensOut = append(tokensOut, tok)
+			sqlText = sqlText[1:]
+		}
+	}
+	return tokensOut
+}

--- a/gosqlparse/sql/token.go
+++ b/gosqlparse/sql/token.go
@@ -1,0 +1,41 @@
+package sql
+
+import (
+	"gosqlparse/tokens"
+)
+
+// Token represents a lexical token with optional hierarchical info.
+type Token struct {
+	Type         tokens.TokenType
+	Value        string
+	Parent       *TokenList
+	IsKeyword    bool
+	IsGroup      bool
+	IsWhitespace bool
+	IsNewline    bool
+}
+
+// TokenList is a list of tokens that can itself act as a token.
+type TokenList struct {
+	Token
+	Tokens []*Token
+}
+
+func NewTokenList(toks []*Token) *TokenList {
+	tl := &TokenList{Tokens: toks}
+	tl.Type = tokens.Illegal
+	tl.IsGroup = true
+	for _, t := range tl.Tokens {
+		t.Parent = tl
+	}
+	return tl
+}
+
+// Statement represents a full SQL statement.
+type Statement struct {
+	*TokenList
+}
+
+func NewStatement(toks []*Token) *Statement {
+	return &Statement{NewTokenList(toks)}
+}

--- a/gosqlparse/sqlparse.go
+++ b/gosqlparse/sqlparse.go
@@ -1,0 +1,15 @@
+package gosqlparse
+
+import (
+	"gosqlparse/engine/filterstack"
+	"gosqlparse/sql"
+)
+
+// Parse returns parsed SQL statements with optional grouping.
+func Parse(sqlText string, grouping bool) []*sql.Statement {
+	fs := filterstack.New()
+	if grouping {
+		fs.EnableGrouping()
+	}
+	return fs.Run(sqlText)
+}

--- a/gosqlparse/tokens/token.go
+++ b/gosqlparse/tokens/token.go
@@ -1,0 +1,39 @@
+package tokens
+
+// TokenType defines SQL token categories.
+// This is a minimal subset for demonstration.
+type TokenType int
+
+const (
+	Illegal TokenType = iota
+	Whitespace
+	Keyword
+	Identifier
+	Operator
+	String
+	Number
+	Punctuation
+)
+
+func (t TokenType) String() string {
+	switch t {
+	case Illegal:
+		return "Illegal"
+	case Whitespace:
+		return "Whitespace"
+	case Keyword:
+		return "Keyword"
+	case Identifier:
+		return "Identifier"
+	case Operator:
+		return "Operator"
+	case String:
+		return "String"
+	case Number:
+		return "Number"
+	case Punctuation:
+		return "Punctuation"
+	default:
+		return "Unknown"
+	}
+}


### PR DESCRIPTION
## Summary
- start skeleton Go port of sqlparse
- define basic token types, lexer, statement splitter
- add filter stack and placeholder grouping

## Testing
- `go mod tidy`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_b_686bab15d2208329898620cf19b0842f