### PR TITLE
Add Go framework skeleton

### DIFF
--- a/goSqlParse/README.md
+++ b/goSqlParse/README.md
@@ -1,0 +1,6 @@
+# gosqlparse (work in progress)
+
+This directory contains an experimental Go port of the Python `sqlparse` library.
+Currently only basic type definitions and package skeletons exist. Further
+implementation will mirror the original project's lexer, parser, and grouping
+logic.

--- a/goSqlParse/engine/filterstack.go
+++ b/goSqlParse/engine/filterstack.go
@@ -1,0 +1,22 @@
+package engine
+
+import "gosqlparse/sql"
+
+// Filter defines an interface for token filters.
+type Filter interface {
+	Process([]sql.Token) []sql.Token
+}
+
+// FilterStack coordinates filters and grouping.
+type FilterStack struct {
+	preprocess []Filter
+}
+
+// New returns a new FilterStack.
+func New() *FilterStack { return &FilterStack{} }
+
+// Run executes the filter stack on the given SQL string.
+func (fs *FilterStack) Run(input string) []*sql.Statement {
+	// TODO: tokenizer and grouping will be implemented later.
+	return nil
+}

--- a/goSqlParse/filters/filter.go
+++ b/goSqlParse/filters/filter.go
@@ -1,0 +1,8 @@
+package filters
+
+import "gosqlparse/sql"
+
+// FilterFunc wraps a function to implement engine.Filter.
+type FilterFunc func([]sql.Token) []sql.Token
+
+func (f FilterFunc) Process(toks []sql.Token) []sql.Token { return f(toks) }

--- a/goSqlParse/formatter/formatter.go
+++ b/goSqlParse/formatter/formatter.go
@@ -1,0 +1,3 @@
+package formatter
+
+// TODO: formatting options will be implemented later.

--- a/goSqlParse/go.mod
+++ b/goSqlParse/go.mod
@@ -1,0 +1,3 @@
+module gosqlparse
+
+go 1.23.8

--- a/goSqlParse/lexer/lexer.go
+++ b/goSqlParse/lexer/lexer.go
@@ -1,0 +1,14 @@
+package lexer
+
+import (
+	"gosqlparse/sql"
+	"gosqlparse/tokens"
+)
+
+// Tokenize splits the input SQL string into tokens.
+func Tokenize(input string) []sql.Token {
+	// TODO: implement regex-based tokenizer.
+	return []sql.Token{
+		{Type: tokens.Other, Value: input},
+	}
+}

--- a/goSqlParse/sql/comparison.go
+++ b/goSqlParse/sql/comparison.go
@@ -1,0 +1,4 @@
+package sql
+
+// Comparison represents a comparison expression.
+type Comparison struct{ TokenList }

--- a/goSqlParse/sql/function.go
+++ b/goSqlParse/sql/function.go
@@ -1,0 +1,4 @@
+package sql
+
+// Function represents a SQL function call.
+type Function struct{ TokenList }

--- a/goSqlParse/sql/identifier.go
+++ b/goSqlParse/sql/identifier.go
@@ -1,0 +1,4 @@
+package sql
+
+// Identifier represents a single identifier.
+type Identifier struct{ TokenList }

--- a/goSqlParse/sql/identifier_list.go
+++ b/goSqlParse/sql/identifier_list.go
@@ -1,0 +1,4 @@
+package sql
+
+// IdentifierList represents a list of identifiers.
+type IdentifierList struct{ TokenList }

--- a/goSqlParse/sql/parenthesis.go
+++ b/goSqlParse/sql/parenthesis.go
@@ -1,0 +1,4 @@
+package sql
+
+// Parenthesis represents a parenthesized expression.
+type Parenthesis struct{ TokenList }

--- a/goSqlParse/sql/statement.go
+++ b/goSqlParse/sql/statement.go
@@ -1,0 +1,4 @@
+package sql
+
+// Statement represents a top-level SQL statement.
+type Statement struct{ TokenList }

--- a/goSqlParse/sql/token.go
+++ b/goSqlParse/sql/token.go
@@ -1,0 +1,13 @@
+package sql
+
+import "gosqlparse/tokens"
+
+// Token represents a single SQL token.
+type Token struct {
+	Type  tokens.TokenType
+	Value string
+}
+
+func (t Token) String() string {
+	return t.Value
+}

--- a/goSqlParse/sql/tokenlist.go
+++ b/goSqlParse/sql/tokenlist.go
@@ -1,0 +1,12 @@
+package sql
+
+// TokenList represents a list of tokens.
+type TokenList struct {
+	Tokens []Token
+}
+
+// Len returns number of tokens.
+func (tl *TokenList) Len() int { return len(tl.Tokens) }
+
+// Append adds a token to the list.
+func (tl *TokenList) Append(tok Token) { tl.Tokens = append(tl.Tokens, tok) }

--- a/goSqlParse/sql/where.go
+++ b/goSqlParse/sql/where.go
@@ -1,0 +1,4 @@
+package sql
+
+// Where represents a WHERE clause.
+type Where struct{ TokenList }

--- a/goSqlParse/tokens/tokens.go
+++ b/goSqlParse/tokens/tokens.go
@@ -1,0 +1,16 @@
+package tokens
+
+// TokenType represents the general classification of a token.
+type TokenType int
+
+const (
+	Illegal TokenType = iota
+	Keyword
+	Identifier
+	Literal
+	Operator
+	Comment
+	Whitespace
+	Punctuation
+	Other
+)


### PR DESCRIPTION
## Summary
- add `goSqlParse` folder with Go module and placeholder packages
- define basic `TokenType` enum and token structs
- provide skeleton types for statements and identifiers
- outline filter stack and lexer entry points

## Testing
- `pytest -q`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_686f527fec2483299fc2637b82ad85b3